### PR TITLE
Use service instead of plist

### DIFF
--- a/Formula/surreal.rb
+++ b/Formula/surreal.rb
@@ -20,36 +20,12 @@ class Surreal < Formula
   EOS
   end
 
-  plist_options :manual => "surreal start --user root --pass root --log debug memory"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>#{plist_name}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>#{opt_bin}/surreal</string>
-        <string>start</string>
-        <string>--user</string>
-        <string>root</string>
-        <string>--pass</string>
-        <string>root</string>
-        <string>--log</string>
-        <string>debug</string>
-        <string>file://#{var}/surreal.db</string>
-      </array>
-      <key>WorkingDirectory</key>
-      <string>#{var}</string>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <true/>
-    </dict>
-    </plist>
-  EOS
+  service do
+    run [
+      #{opt_bin}/surreal start --user root --pass root debug file://#{var}/surreal.db
+    ]
+    working_dir #{var}
+    keep_alive true
   end
 
   test do


### PR DESCRIPTION
When starting the service, homebrew returns a warning regarding the deprecated `plist_options` and suggests using `service.require_root` instead.

```bash
brew services start surrealdb/tap/surreal
Warning: Calling plist_options is deprecated! Use service.require_root instead.
```

This PR proposes to use the service block method to generate the service file.

Homebrew doc reference:
https://docs.brew.sh/Formula-Cookbook#service-files 