### PR TITLE
Corrected invalid Ruby code for defining the surreal service

### DIFF
--- a/Formula/surreal-nightly.rb
+++ b/Formula/surreal-nightly.rb
@@ -22,9 +22,9 @@ class SurrealNightly < Formula
 
   service do
     run [
-      #{opt_bin}/surreal start --user root --pass root debug file://#{var}/surreal.db
+      opt_bin/"surreal", "start", "--user", "root", "--pass", "root", "--log", "debug", "file://#{var}/surreal.db"
     ]
-    working_dir #{var}
+    working_dir "#{var}"
     keep_alive true
   end
 

--- a/Formula/surreal.rb
+++ b/Formula/surreal.rb
@@ -22,9 +22,9 @@ class Surreal < Formula
 
   service do
     run [
-      #{opt_bin}/surreal start --user root --pass root debug file://#{var}/surreal.db
+      opt_bin/"surreal", "start", "--user", "root", "--pass", "root", "--log", "debug", "file://#{var}/surreal.db"
     ]
-    working_dir #{var}
+    working_dir "#{var}"
     keep_alive true
   end
 


### PR DESCRIPTION
The code previously used to define the surreal service had a few issues:

* Ruby string interopolation is used outside of a string context causing the service section to be ignored.
* Did not quote strings nor use comma separation within a Ruby list.
* Missed the `--log` option before `debug` within the `surreal start` command.

Attempting to start a Surreal DB with `brew services start surreal` resulted an error:

```
surreal has not implemented #plist, #service or installed a locatable service 
```

This update uses valid Ruby, allowing Homebrew to create a launchd service file and uses valid `surreal start` command line to start the database.